### PR TITLE
fix Fastfile.write cannot write buf larger than cache size(256KiB)

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -191,8 +191,8 @@ class FastFile {
             r = r-l;
             p ++;
             o = 0;
+            setImmediate(self._triggerWrite.bind(self));
         }
-        setImmediate(self._triggerWrite.bind(self));
     }
 
     async read(len, pos) {

--- a/src/osfile.js
+++ b/src/osfile.js
@@ -186,8 +186,8 @@ class FastFile {
             r = r-l;
             p ++;
             o = 0;
+            setImmediate(self._triggerWrite.bind(self));
         }
-        setImmediate(self._triggerWrite.bind(self));
     }
 
     async read(len, pos) {


### PR DESCRIPTION
I cannot run this command: 

```
snarkjs powersoftau contribute pot12_0000.ptau pot12_0001.ptau --name="First contribution" -v
```

This command hangs.
After some debugging, I found this is due to fastfile hangs.    
After [this commit](https://github.com/iden3/fastfile/commit/0ede1cdd73f4d0666ea2fbd470b1e58f66117e83), when called with more than 256KiB data, Fastfile.write will hang because after pushing 256KiB data into `pages`, [await self._loadPage(p)](https://github.com/iden3/fastfile/blob/master/src/osfile.js#L175) will never return because
the load promise will [neither resolve nor reject](https://github.com/iden3/fastfile/blob/master/src/osfile.js#L62).    
So here I changed the location of the `_triggerWrite`, now load & write can happen simultaneously, so everything is  ok. 

You can test this bug and the fix with this code snippet:

```
const fastFile = require("fastfile");

async function writeFile() {
    const f = await fastFile.createOverride("pattern.bin");
    await f.write(new Uint8Array(10 * 1024 * 1024));
    await f.close();
}

async function readFile() {
    const f = await fastFile.readExisting("pattern.bin");

    const buff = await f.read(16, 8);

    await f.close();

    return buff;

}

writeFile().then( () => {
    readFile().then( (buff) => {
        console.log(buff.toString("hex"));
    });
});
```