### PR TITLE
fix: Use explicit constant flags instead of string flags

### DIFF
--- a/src/fastfile.js
+++ b/src/fastfile.js
@@ -2,6 +2,7 @@
 import { open } from "./osfile.js";
 import * as memFile from "./memfile.js";
 import * as bigMemFile from "./bigmemfile.js";
+import { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } from "constants";
 
 const DEFAULT_CACHE_SIZE = (1 << 16);
 const DEFAULT_PAGE_SIZE = (1 << 13);
@@ -17,7 +18,7 @@ export async function createOverride(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return await open(o.fileName, "w+", o.cacheSize, o.pageSize);
+        return await open(o.fileName, O_TRUNC | O_CREAT | O_RDWR, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return memFile.createNew(o);
     } else if (o.type == "bigMem") {
@@ -37,7 +38,7 @@ export function createNoOverride(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return open(o.fileName, "wx+", o.cacheSize, o.pageSize);
+        return open(o.fileName, O_TRUNC | O_CREAT | O_RDWR | O_EXCL, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return memFile.createNew(o);
     } else if (o.type == "bigMem") {
@@ -77,7 +78,7 @@ export async function readExisting(o, b, c) {
         }
     }
     if (o.type == "file") {
-        return await open(o.fileName, "r", o.cacheSize, o.pageSize);
+        return await open(o.fileName, O_RDONLY, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return await memFile.readExisting(o);
     } else if (o.type == "bigMem") {
@@ -97,7 +98,7 @@ export function readWriteExisting(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return open(o.fileName, "a+", o.cacheSize, o.pageSize);
+        return open(o.fileName, O_CREAT | O_RDWR, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return memFile.readWriteExisting(o);
     } else if (o.type == "bigMem") {
@@ -117,7 +118,7 @@ export function readWriteExistingOrCreate(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return open(o.fileName, "ax+", o.cacheSize);
+        return open(o.fileName, O_CREAT | O_RDWR | O_EXCL, o.cacheSize);
     } else if (o.type == "mem") {
         return memFile.readWriteExisting(o);
     } else if (o.type == "bigMem") {

--- a/src/osfile.js
+++ b/src/osfile.js
@@ -3,7 +3,7 @@ import fs from"fs";
 
 export async function open(fileName, openFlags, cacheSize, pageSize) {
     cacheSize = cacheSize || 4096*64;
-    if (["w+", "wx+", "r", "ax+", "a+"].indexOf(openFlags) <0)
+    if (typeof openFlags !== "number" && ["w+", "wx+", "r", "ax+", "a+"].indexOf(openFlags) <0)
         throw new Error("Invalid open option");
     const fd =await fs.promises.open(fileName, openFlags);
 


### PR DESCRIPTION
This fixes a bug with "a+" flag on Windows and Linux

The flags are based on https://github.com/nodejs/node/blob/aba2cd74dce406da2f3dcf6a2bd08d9552fa3671/lib/internal/fs/utils.js#L556 but adjusted so we don't use `O_APPEND` because it causes the append-only bug in Linux and Windows.