### PR TITLE
AVoid 'Too many promises' error

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -39,6 +39,7 @@ class FastFile {
         this.reading = false;
         this.avBuffs = [];
         this.history = {};
+        this.maxPromises = 1 << 3;
     }
 
     _loadPage(p) {
@@ -114,8 +115,8 @@ class FastFile {
         while (
             (self.pendingLoads.length>0) &&
             (   (typeof self.pages[self.pendingLoads[0].page] != "undefined" )
-              ||(  (freePages>0)
-                 ||(deletablePages.length>0)))) {
+            ||(  (freePages>0)
+                ||(deletablePages.length>0)))) {
             const load = self.pendingLoads.shift();
             if (typeof self.pages[load.page] != "undefined") {
                 self.pages[load.page].pendingOps ++;
@@ -165,7 +166,16 @@ class FastFile {
         }
         // if (ops.length>1) console.log(ops.length);
 
-        Promise.all(ops).then( () => {
+        // This attempts to avoid 'too many promises for Promise.all' error
+        const opsWrapper = [];
+        for (let from=0; from<ops.length; from+=this.maxPromises) {
+            let to = from+this.maxPromises;
+            if (to > ops.length) to = ops.length;
+            const opsSlice = ops.slice(from, to);
+            opsWrapper.push(Promise.all(opsSlice));
+        }
+
+        Promise.all(opsWrapper).then( () => {
             self.reading = false;
             if (self.pendingLoads.length>0) setImmediate(self._triggerLoad.bind(self));
             self._tryClose();

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -39,7 +39,7 @@ class FastFile {
         this.reading = false;
         this.avBuffs = [];
         this.history = {};
-        this.maxPromises = 1 << 3;
+        this.maxPromises = 1 << 10;
     }
 
     _loadPage(p) {
@@ -166,11 +166,10 @@ class FastFile {
         }
         // if (ops.length>1) console.log(ops.length);
 
-        // This attempts to avoid 'too many promises for Promise.all' error
+        // This avoids 'too many promises for Promise.all' error
         const opsWrapper = [];
         for (let from=0; from<ops.length; from+=this.maxPromises) {
-            let to = from+this.maxPromises;
-            if (to > ops.length) to = ops.length;
+            let to = Math.min(from+this.maxPromises, ops.length);
             const opsSlice = ops.slice(from, to);
             opsWrapper.push(Promise.all(opsSlice));
         }

--- a/src/osfile.js
+++ b/src/osfile.js
@@ -32,7 +32,7 @@ class FastFile {
         this.reading = false;
         this.avBuffs = [];
         this.history = {};
-        this.maxPromises = 1 << 3;
+        this.maxPromises = 1 << 10;
     }
 
     _loadPage(p) {
@@ -159,11 +159,10 @@ class FastFile {
         }
         // if (ops.length>1) console.log(ops.length);
 
-        // This attempts to avoid 'too many promises for Promise.all' error
+        // This avoids 'too many promises for Promise.all' error
         const opsWrapper = [];
         for (let from=0; from<ops.length; from+=this.maxPromises) {
-            let to = from+this.maxPromises;
-            if (to > ops.length) to = ops.length;
+            let to = Math.min(from+this.maxPromises, ops.length);
             const opsSlice = ops.slice(from, to);
             opsWrapper.push(Promise.all(opsSlice));
         }

--- a/test/osfile.test.js
+++ b/test/osfile.test.js
@@ -49,6 +49,16 @@ describe("fastfile testing suite for osfile", function () {
         expect(fd.readString(0)).to.be.rejectedWith("Reading a closing file");
         await fs.promises.unlink(fileName);
     });
+
+    it("should read a large file", async () => {
+        const fileName = "//wsl.localhost/Ubuntu/home/geoff/ptau/pot10_0006_bcn_prep.ptau";
+        const ff = await fastFile.readExisting(fileName, 1024, 1024);
+        assert(ff.totalSize>0);
+
+        let buff = new Uint8Array(1024);
+        await ff.readToBuffer(buff, 0, 1024);
+        assert.equal(ff.pos, 1024);
+    });
 });
 
 

--- a/test/osfile.test.js
+++ b/test/osfile.test.js
@@ -52,12 +52,13 @@ describe("fastfile testing suite for osfile", function () {
 
     it("should read a large file", async () => {
         const fileName = "//wsl.localhost/Ubuntu/home/geoff/ptau/pot10_0006_bcn_prep.ptau";
+        const bytesToRead = 1<<16;
         const ff = await fastFile.readExisting(fileName, 1024, 1024);
         assert(ff.totalSize>0);
 
-        let buff = new Uint8Array(1024);
-        await ff.readToBuffer(buff, 0, 1024);
-        assert.equal(ff.pos, 1024);
+        let buff = new Uint8Array(bytesToRead);
+        await ff.readToBuffer(buff, 0, bytesToRead);
+        assert.equal(ff.pos, bytesToRead);
     });
 });
 

--- a/test/osfile.test.js
+++ b/test/osfile.test.js
@@ -51,7 +51,7 @@ describe("fastfile testing suite for osfile", function () {
     });
 
     it("should read a large file", async () => {
-        const fileName = "//wsl.localhost/Ubuntu/home/geoff/ptau/pot10_0006_bcn_prep.ptau";
+        const fileName = "//path/to/large/file.ptau";
         const bytesToRead = 1<<16;
         const ff = await fastFile.readExisting(fileName, 1024, 1024);
         assert(ff.totalSize>0);


### PR DESCRIPTION
See issue #101

A 'Range Error: Too many promises' error is thrown when reading a large file from disk. This error prevents running commands such as 'snarkjs powersoftau prepare phase2' on large files. In such circumstances, the number of promises reaches a limit inherent to node.js.

It is possible to circumvent the error by customising the node.js installation to insert a larger limit. This PR takes the approach of wrapping the promises array in an extra layer of batched promises. Large files can then be read with a native installation of node.js.

I have tested this code by successfully reading chunks of 34gb of data, sufficient to process a 2^28 powers of tau file.