### PR TITLE
Fix rollup build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous Integration
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:
@@ -10,14 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: ["12", "14", "16", "18"]
+        node-version: [lts/*, lts/-1]
 
     steps:
       - name: Checkout project
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
 var fs = require('fs');
-var node_fs = require('node:fs');
+var constants = require('constants');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
@@ -898,8 +898,6 @@ class BigMemFile {
     }
 }
 
-const { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } = node_fs.constants;
-
 const DEFAULT_CACHE_SIZE = (1 << 16);
 const DEFAULT_PAGE_SIZE = (1 << 13);
 
@@ -914,13 +912,13 @@ async function createOverride(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return await open(o.fileName, O_TRUNC | O_CREAT | O_RDWR, o.cacheSize, o.pageSize);
+        return await open(o.fileName, constants.O_TRUNC | constants.O_CREAT | constants.O_RDWR, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return createNew$1(o);
     } else if (o.type == "bigMem") {
         return createNew(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -934,13 +932,13 @@ function createNoOverride(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return open(o.fileName, O_TRUNC | O_CREAT | O_RDWR | O_EXCL, o.cacheSize, o.pageSize);
+        return open(o.fileName, constants.O_TRUNC | constants.O_CREAT | constants.O_RDWR | constants.O_EXCL, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return createNew$1(o);
     } else if (o.type == "bigMem") {
         return createNew(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -953,7 +951,7 @@ async function readExisting(o, b, c) {
     }
     if (process.browser) {
         if (typeof o === "string") {
-            const buff = await fetch(o).then( function(res) {
+            const buff = await fetch(o).then(function (res) {
                 return res.arrayBuffer();
             }).then(function (ab) {
                 return new Uint8Array(ab);
@@ -974,13 +972,13 @@ async function readExisting(o, b, c) {
         }
     }
     if (o.type == "file") {
-        return await open(o.fileName, O_RDONLY, o.cacheSize, o.pageSize);
+        return await open(o.fileName, constants.O_RDONLY, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return await readExisting$2(o);
     } else if (o.type == "bigMem") {
         return await readExisting$1(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -994,13 +992,13 @@ function readWriteExisting(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return open(o.fileName, O_CREAT | O_RDWR, o.cacheSize, o.pageSize);
+        return open(o.fileName, constants.O_CREAT | constants.O_RDWR, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
         return readWriteExisting$2(o);
     } else if (o.type == "bigMem") {
         return readWriteExisting$1(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -1014,13 +1012,13 @@ function readWriteExistingOrCreate(o, b, c) {
         };
     }
     if (o.type == "file") {
-        return open(o.fileName, O_CREAT | O_RDWR | O_EXCL, o.cacheSize);
+        return open(o.fileName, constants.O_CREAT | constants.O_RDWR | constants.O_EXCL, o.cacheSize);
     } else if (o.type == "mem") {
         return readWriteExisting$2(o);
     } else if (o.type == "bigMem") {
         return readWriteExisting$1(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
 var fs = require('fs');
+var node_fs = require('node:fs');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
@@ -897,7 +898,7 @@ class BigMemFile {
     }
 }
 
-const { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } = fs.constants;
+const { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } = node_fs.constants;
 
 const DEFAULT_CACHE_SIZE = (1 << 16);
 const DEFAULT_PAGE_SIZE = (1 << 13);

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -317,6 +318,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
       "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -546,6 +548,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1909,7 +1912,8 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -2021,6 +2025,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
       "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -2186,6 +2191,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/src/fastfile.js
+++ b/src/fastfile.js
@@ -1,7 +1,7 @@
 import { open } from "./osfile.js";
 import * as memFile from "./memfile.js";
 import * as bigMemFile from "./bigmemfile.js";
-import { constants } from "fs";
+import { constants } from "node:fs";
 
 const { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } = constants;
 

--- a/src/fastfile.js
+++ b/src/fastfile.js
@@ -1,9 +1,8 @@
 import { open } from "./osfile.js";
 import * as memFile from "./memfile.js";
 import * as bigMemFile from "./bigmemfile.js";
-import { constants } from "node:fs";
+import { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } from "constants";
 
-const { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } = constants;
 
 const DEFAULT_CACHE_SIZE = (1 << 16);
 const DEFAULT_PAGE_SIZE = (1 << 13);
@@ -25,7 +24,7 @@ export async function createOverride(o, b, c) {
     } else if (o.type == "bigMem") {
         return bigMemFile.createNew(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -45,7 +44,7 @@ export function createNoOverride(o, b, c) {
     } else if (o.type == "bigMem") {
         return bigMemFile.createNew(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -58,7 +57,7 @@ export async function readExisting(o, b, c) {
     }
     if (process.browser) {
         if (typeof o === "string") {
-            const buff = await fetch(o).then( function(res) {
+            const buff = await fetch(o).then(function (res) {
                 return res.arrayBuffer();
             }).then(function (ab) {
                 return new Uint8Array(ab);
@@ -85,7 +84,7 @@ export async function readExisting(o, b, c) {
     } else if (o.type == "bigMem") {
         return await bigMemFile.readExisting(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -105,7 +104,7 @@ export function readWriteExisting(o, b, c) {
     } else if (o.type == "bigMem") {
         return bigMemFile.readWriteExisting(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }
 
@@ -125,6 +124,6 @@ export function readWriteExistingOrCreate(o, b, c) {
     } else if (o.type == "bigMem") {
         return bigMemFile.readWriteExisting(o);
     } else {
-        throw new Error("Invalid FastFile type: "+o.type);
+        throw new Error("Invalid FastFile type: " + o.type);
     }
 }


### PR DESCRIPTION
This pull request updates both the CI workflow and the way file system constants are imported and used in the codebase. The main goals are to modernize CI Node.js version handling and to standardize the import of file system constants for better compatibility and clarity.

**CI/CD Workflow Improvements:**

* The CI workflow now only runs on pushes to the `main` branch and on pull requests, instead of all branches. (`.github/workflows/ci.yml`)
* Node.js versions in the CI matrix now use `lts/*` and `lts/-1` for broader and more future-proof coverage, and the `actions/setup-node` action is updated to v4. (`.github/workflows/ci.yml`)

**File System Constants Refactoring:**

* In `src/fastfile.js`, file system constants are now imported directly from the `constants` module, rather than destructured from `fs.constants`, improving clarity and compatibility. (`src/fastfile.js`)
* In `build/main.cjs`, all uses of file system constants are updated to reference `constants` (e.g., `constants.O_TRUNC`) instead of relying on destructured variables, and the `constants` module is explicitly required. (`build/main.cjs`) [[1]](diffhunk://#diff-97ab8679b549ee4348bb7108b50a8eaa0d8a8dae36678a0074143bd919a787f2R6) [[2]](diffhunk://#diff-97ab8679b549ee4348bb7108b50a8eaa0d8a8dae36678a0074143bd919a787f2L900-L901) [[3]](diffhunk://#diff-97ab8679b549ee4348bb7108b50a8eaa0d8a8dae36678a0074143bd919a787f2L916-R915) [[4]](diffhunk://#diff-97ab8679b549ee4348bb7108b50a8eaa0d8a8dae36678a0074143bd919a787f2L936-R935) [[5]](diffhunk://#diff-97ab8679b549ee4348bb7108b50a8eaa0d8a8dae36678a0074143bd919a787f2L976-R975) [[6]](diffhunk://#diff-97ab8679b549ee4348bb7108b50a8eaa0d8a8dae36678a0074143bd919a787f2L996-R995) [[7]](diffhunk://#diff-97ab8679b549ee4348bb7108b50a8eaa0d8a8dae36678a0074143bd919a787f2L1016-R1015)