### PR TITLE
Stream reads over HTTP Range requests and from Blobs

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -164,7 +164,17 @@ class FastFile {
                         self.__statusPage("After Load (loaded): ", load.page);
                         return res;
                     }, (err) => {
-                        load.reject(err);
+                        // Reject EVERY waiter, not just the first: co-readers of the
+                        // same page were appended to page.loading (not to `load`) and
+                        // would otherwise await forever. Drop the page entirely so a
+                        // later retry re-reads it instead of queueing onto a dead
+                        // loading list.
+                        const page = self.pages[load.page];
+                        const loading = (page && page.loading) ? page.loading : [load];
+                        delete self.pages[load.page];
+                        for (let i=0; i<loading.length; i++) {
+                            loading[i].reject(err);
+                        }
                     }));
                     self.__statusPage("After Load (loading): ", load.page);
                 }
@@ -217,6 +227,13 @@ class FastFile {
                     return;
                 }, (err) => {
                     console.log("ERROR Writing: "+err);
+                    // Clear `writing` (a stuck flag pins the page forever and
+                    // blocks _tryClose) and record the error. write()/read()
+                    // surface it on their next call (fail fast) and close()
+                    // rejects with it -- previously it was only visible at
+                    // close(), so a prover that skipped close on error paths
+                    // silently produced a truncated/corrupt file.
+                    page.writing = false;
                     self.error = err;
                     self._tryClose();
                 }));
@@ -256,6 +273,7 @@ class FastFile {
     async write(buff, pos) {
         if (buff.byteLength == 0) return;
         const self = this;
+        if (self.error) throw self.error;
         if (typeof pos == "undefined") pos = self.pos;
         self.pos = pos+buff.byteLength;
         if (self.totalSize < pos + buff.byteLength) self.totalSize = pos + buff.byteLength;
@@ -338,6 +356,7 @@ class FastFile {
             return;
         }
         const self = this;
+        if (self.error) throw self.error;
         if (typeof pos == "undefined") pos = self.pos;
         self.pos = pos+len;
         if (self.pendingClose)
@@ -376,8 +395,16 @@ class FastFile {
 
         let p = firstPage;
         let o = pos % self.pageSize;
-        // Remaining bytes to read
+        // Remaining bytes to read (clamped to EOF: a read past the end of a
+        // truncated/short file reads fewer bytes than requested).
         let r = pos + len > self.totalSize ? len - (pos + len - self.totalSize): len;
+        // Bytes already written to buffDst -- tracked independently of `r`
+        // (which shrinks on EOF-clamping) so the destination offset stays
+        // correct. Previously computed as `offset + len - r`: with `r`
+        // pre-clamped below `len`, that put the first bytes read at a
+        // nonzero offset instead of the real EOF-truncated tail, silently
+        // shifting valid data to the wrong position in the output buffer.
+        let done = 0;
         while (r>0) {
             await pagePromises[p - firstPage];
             self.__statusPage("After Await (read): ", p);
@@ -385,12 +412,13 @@ class FastFile {
             // bytes to copy from this page
             const l = (o+r > self.pageSize) ? (self.pageSize -o) : r;
             const srcView = new Uint8Array(self.pages[p].buff.buffer, self.pages[p].buff.byteOffset + o, l);
-            buffDst.set(srcView, offset+len-r);
+            buffDst.set(srcView, offset+done);
             self.pages[p].pendingOps --;
 
             self.__statusPage("After Op done: ", p);
 
             r = r-l;
+            done = done+l;
             p ++;
             o = 0;
             if (self.pendingLoads.length>0) setImmediate(self._triggerLoad.bind(self));
@@ -406,6 +434,7 @@ class FastFile {
         if (!self.pendingClose) return;
         if (self.error) {
             self.pendingCloseReject(self.error);
+            return;
         }
         const p = self._getDirtyPage();
         if ((p>=0) || (self.writing) || (self.reading) || (self.pendingLoads.length>0)) return;
@@ -559,7 +588,7 @@ function createNew$1(o) {
     return fd;
 }
 
-function readExisting$2(o) {
+function readExisting$4(o) {
     const fd = new MemFile();
     fd.o = o;
     fd.allocSize = o.data.byteLength;
@@ -755,7 +784,7 @@ function createNew(o) {
     return fd;
 }
 
-function readExisting$1(o) {
+function readExisting$3(o) {
     const fd = new BigMemFile();
     fd.o = o;
     fd.totalSize = (o.data.length-1)* PAGE_SIZE + o.data[o.data.length-1].byteLength;
@@ -966,6 +995,317 @@ class BigMemFile {
     }
 }
 
+// Shared read-only file over an abstract positioned range reader.
+//
+// Backends (httpfile, blobfile) supply a single primitive:
+//     readRangeInto(dstBuff, dstOffset, pos, len) -> Promise<void>
+// and this class layers the FastFile read interface on top:
+//   - reads >= pageSize bypass the cache and go straight to the backend
+//     (the file is read-only, so a direct read is always coherent);
+//   - smaller reads (header scans: magics, section tables, ULE32/64) are
+//     served from page-aligned cached ranges so that e.g. a binfile section
+//     scan does not issue one backend request per 4-byte field.
+//
+// Write operations throw: remote ranges are strictly a read transport.
+
+const DEFAULT_CACHE_SIZE$1 = 1 << 20;
+const DEFAULT_PAGE_SIZE$1 = 1 << 13;
+
+class RangeFile {
+
+    constructor(readRangeInto, totalSize, cacheSize, pageSize) {
+        this.readRangeInto = readRangeInto;
+        this.totalSize = totalSize;
+        this.pos = 0;
+        this.pageSize = pageSize || DEFAULT_PAGE_SIZE$1;
+        this.maxPagesLoaded = Math.floor((cacheSize || DEFAULT_CACHE_SIZE$1) / this.pageSize) + 1;
+        this.pages = new Map();      // page index -> { buff: Uint8Array|null, promise: Promise }
+        this.readOnly = true;
+    }
+
+    _pageLen(p) {
+        const start = p * this.pageSize;
+        const end = Math.min(start + this.pageSize, this.totalSize);
+        return end - start;
+    }
+
+    // Load (or join the in-flight load of) page p; resolves to its buffer.
+    // A failed load removes the entry so a later retry re-requests it.
+    _loadPage(p) {
+        const self = this;
+        let page = self.pages.get(p);
+        if (page) {
+            // LRU touch: re-insert so Map iteration order tracks recency.
+            self.pages.delete(p);
+            self.pages.set(p, page);
+            return page.promise;
+        }
+        const buff = new Uint8Array(self._pageLen(p));
+        page = { buff: null, promise: null };
+        page.promise = self.readRangeInto(buff, 0, p * self.pageSize, buff.byteLength).then(function () {
+            page.buff = buff;
+            return buff;
+        }, function (err) {
+            self.pages.delete(p);
+            throw err;
+        });
+        self.pages.set(p, page);
+        self._trimCache();
+        return page.promise;
+    }
+
+    _trimCache() {
+        const self = this;
+        if (self.pages.size <= self.maxPagesLoaded) return;
+        // Evict oldest settled pages first; in-flight loads are kept.
+        for (const entry of self.pages) {
+            if (self.pages.size <= self.maxPagesLoaded) return;
+            if (entry[1].buff) self.pages.delete(entry[0]);
+        }
+    }
+
+    async readToBuffer(buffDst, offset, len, pos) {
+        const self = this;
+        if (len === 0) return;
+        if (self.pendingClose) throw new Error("Reading a closing file");
+        if (typeof pos === "undefined") pos = self.pos;
+        if (pos + len > self.totalSize) throw new Error("Reading out of bounds");
+        self.pos = pos + len;
+
+        // Direct path: one backend request straight into the destination
+        // (works for both typed arrays and BigBuffer via .set()).
+        if (len >= self.pageSize) {
+            await self.readRangeInto(buffDst, offset, pos, len);
+            return;
+        }
+
+        const firstPage = Math.floor(pos / self.pageSize);
+        const lastPage = Math.floor((pos + len - 1) / self.pageSize);
+        let o = pos % self.pageSize;
+        let done = 0;
+        for (let p = firstPage; p <= lastPage; p++) {
+            const buff = await self._loadPage(p);
+            const l = Math.min(len - done, self.pageSize - o);
+            buffDst.set(buff.subarray(o, o + l), offset + done);
+            done += l;
+            o = 0;
+        }
+    }
+
+    async read(len, pos) {
+        const buff = new Uint8Array(len);
+        await this.readToBuffer(buff, 0, len, pos);
+        return buff;
+    }
+
+    async readULE32(pos) {
+        const b = await this.read(4, pos);
+        const view = new Uint32Array(b.buffer);
+        return view[0];
+    }
+
+    async readUBE32(pos) {
+        const b = await this.read(4, pos);
+        const view = new DataView(b.buffer);
+        return view.getUint32(0, false);
+    }
+
+    async readULE64(pos) {
+        const b = await this.read(8, pos);
+        const view = new Uint32Array(b.buffer);
+        return view[1] * 0x100000000 + view[0];
+    }
+
+    async readString(pos) {
+        const self = this;
+        if (self.pendingClose) throw new Error("Reading a closing file");
+        let p = typeof pos === "undefined" ? self.pos : pos;
+        const chunks = [];
+        while (p < self.totalSize) {
+            const l = Math.min(self.pageSize, self.totalSize - p);
+            const chunk = await self.read(l, p);
+            const z = chunk.indexOf(0);
+            if (z >= 0) {
+                chunks.push(chunk.subarray(0, z));
+                self.pos = p + z + 1;
+                return decodeChunks(chunks);
+            }
+            chunks.push(chunk);
+            p += l;
+        }
+        // No terminator before EOF: the string ends at EOF.
+        self.pos = p;
+        return decodeChunks(chunks);
+    }
+
+    async write() {
+        throw new Error("Writing a read only file");
+    }
+
+    async writeULE32() {
+        throw new Error("Writing a read only file");
+    }
+
+    async writeUBE32() {
+        throw new Error("Writing a read only file");
+    }
+
+    async writeULE64() {
+        throw new Error("Writing a read only file");
+    }
+
+    async close() {
+        if (this.pendingClose) throw new Error("Closing the file twice");
+        this.pendingClose = true;
+        this.pages.clear();
+    }
+
+    async discard() {
+        await this.close();
+    }
+}
+
+function decodeChunks(chunks) {
+    let total = 0;
+    for (let i = 0; i < chunks.length; i++) total += chunks[i].byteLength;
+    const all = new Uint8Array(total);
+    let o = 0;
+    for (let i = 0; i < chunks.length; i++) {
+        all.set(chunks[i], o);
+        o += chunks[i].byteLength;
+    }
+    return new TextDecoder().decode(all);
+}
+
+// Read-only file over HTTP(S) using Range requests.
+
+async function readExisting$2(o) {
+    const url = o.url;
+    const probe = await fetch(url, { headers: { "Range": "bytes=0-0" } });
+
+    if (probe.status === 206) {
+        const contentRange = probe.headers.get("content-range");
+        const m = contentRange ? /\/(\d+)\s*$/.exec(contentRange) : null;
+        if (m) {
+            const totalSize = parseInt(m[1]);
+            // Drain the 1-byte probe body so the connection can be reused.
+            await probe.arrayBuffer();
+            const validator = strongValidator(probe);
+            const readRangeInto = function (dst, dstOffset, pos, len) {
+                return httpReadRangeInto(url, validator, dst, dstOffset, pos, len);
+            };
+            return new RangeFile(readRangeInto, totalSize, o.cacheSize, o.pageSize);
+        }
+        // 206 but total size unknown (Content-Range: bytes 0-0/*): we cannot
+        // do bounded positioned reads; refetch whole and buffer.
+        await probe.arrayBuffer();
+        return await readFullyToMem(url);
+    }
+
+    if (!probe.ok && probe.status !== 416) {
+        throw new Error("HTTP " + probe.status + " fetching " + url);
+    }
+
+    if (probe.status === 416) {
+        // Range not satisfiable -- only legitimate for an empty file.
+        const contentRange = probe.headers.get("content-range");
+        if (contentRange && /\/0\s*$/.test(contentRange)) {
+            return readExisting$4({ type: "mem", data: new Uint8Array(0) });
+        }
+        return await readFullyToMem(url);
+    }
+
+    // 200: the server ignored Range and sent the whole file; reuse this body.
+    const data = new Uint8Array(await probe.arrayBuffer());
+    return readExisting$4({ type: "mem", data: data });
+}
+
+async function readFullyToMem(url) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error("HTTP " + res.status + " fetching " + url);
+    const data = new Uint8Array(await res.arrayBuffer());
+    return readExisting$4({ type: "mem", data: data });
+}
+
+// Only a strong validator is usable with If-Range (RFC 9110 §13.1.5): a weak
+// ETag would make conditional range requests always fail on some servers.
+function strongValidator(res) {
+    const etag = res.headers.get("etag");
+    if (etag && etag.indexOf("W/") !== 0) return etag;
+    const lastModified = res.headers.get("last-modified");
+    if (lastModified) return lastModified;
+    return null;
+}
+
+async function httpReadRangeInto(url, validator, dst, dstOffset, pos, len) {
+    const headers = { "Range": "bytes=" + pos + "-" + (pos + len - 1) };
+    if (validator) headers["If-Range"] = validator;
+    const res = await fetch(url, { headers: headers });
+    if (res.status === 200) {
+        // With If-Range this is the server signalling the file changed;
+        // without it, the server stopped honoring ranges mid-session.
+        await abandonBody(res);
+        throw new Error(url + ": file changed (or server stopped honoring Range) while reading");
+    }
+    if (res.status !== 206) {
+        await abandonBody(res);
+        throw new Error("HTTP " + res.status + " reading range " + pos + "+" + len + " of " + url);
+    }
+    const contentRange = res.headers.get("content-range");
+    const m = contentRange ? /bytes\s+(\d+)-(\d+)\//.exec(contentRange) : null;
+    if (m && parseInt(m[1]) !== pos) {
+        await abandonBody(res);
+        throw new Error(url + ": server returned range starting at " + m[1] + ", requested " + pos);
+    }
+
+    // Stream the body straight into the destination (typed array or
+    // BigBuffer -- both expose .set(chunk, offset)); avoids materializing
+    // a second full-size copy of large section reads.
+    let done = 0;
+    if (res.body && typeof res.body.getReader === "function") {
+        const reader = res.body.getReader();
+        for (;;) {
+            const it = await reader.read();
+            if (it.done) break;
+            if (done + it.value.byteLength > len) {
+                reader.cancel().catch(function () {});
+                throw new Error(url + ": range response longer than requested");
+            }
+            dst.set(it.value, dstOffset + done);
+            done += it.value.byteLength;
+        }
+    } else {
+        const buff = new Uint8Array(await res.arrayBuffer());
+        if (buff.byteLength > len) throw new Error(url + ": range response longer than requested");
+        dst.set(buff, dstOffset);
+        done = buff.byteLength;
+    }
+    if (done !== len) {
+        throw new Error(url + ": short range response (" + done + "/" + len + " bytes at " + pos + ")");
+    }
+}
+
+async function abandonBody(res) {
+    try {
+        if (res.body && typeof res.body.cancel === "function") await res.body.cancel();
+        else await res.arrayBuffer();
+    } catch (e) { /* body teardown is best-effort */ }
+}
+
+// Read-only file over a Blob/File (e.g. a browser <input type="file">
+
+function readExisting$1(o) {
+    const blob = o.blob;
+    const readRangeInto = async function (dst, dstOffset, pos, len) {
+        const ab = await blob.slice(pos, pos + len).arrayBuffer();
+        if (ab.byteLength !== len) {
+            throw new Error("short blob read (" + ab.byteLength + "/" + len + " bytes at " + pos + ")");
+        }
+        dst.set(new Uint8Array(ab), dstOffset);
+    };
+    return new RangeFile(readRangeInto, blob.size, o.cacheSize, o.pageSize);
+}
+
 const DEFAULT_CACHE_SIZE = (1 << 16);
 const DEFAULT_PAGE_SIZE = (1 << 13);
 
@@ -1021,20 +1361,27 @@ async function readExisting(o, b, c) {
             data: o
         };
     }
-    if (!isNode) {
-        if (typeof o === "string") {
-            const buff = await fetch(o).then( function(res) {
-                return res.arrayBuffer();
-            }).then(function (ab) {
-                return new Uint8Array(ab);
-            });
+    if (typeof Blob !== "undefined" && o instanceof Blob) {
+        o = {
+            type: "blob",
+            blob: o,
+            cacheSize: b,
+            pageSize: c
+        };
+    }
+    if (typeof o === "string") {
+        // URLs (and, in the browser, any string -- historically fetched
+        // whole) go through the http backend: it streams via Range requests
+        // when the server supports them and falls back to buffering the
+        // full body (the previous behavior) when it does not.
+        if (!isNode || /^https?:\/\//i.test(o)) {
             o = {
-                type: "mem",
-                data: buff
+                type: "http",
+                url: o,
+                cacheSize: b,
+                pageSize: c
             };
-        }
-    } else {
-        if (typeof o === "string") {
+        } else {
             o = {
                 type: "file",
                 fileName: o,
@@ -1046,9 +1393,13 @@ async function readExisting(o, b, c) {
     if (o.type == "file") {
         return await open(o.fileName, constants.O_RDONLY, o.cacheSize, o.pageSize);
     } else if (o.type == "mem") {
-        return await readExisting$2(o);
+        return await readExisting$4(o);
     } else if (o.type == "bigMem") {
-        return await readExisting$1(o);
+        return await readExisting$3(o);
+    } else if (o.type == "http") {
+        return await readExisting$2(o);
+    } else if (o.type == "blob") {
+        return readExisting$1(o);
     } else {
         throw new Error("Invalid FastFile type: "+o.type);
     }

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -1179,6 +1179,15 @@ function decodeChunks(chunks) {
 
 // Read-only file over HTTP(S) using Range requests.
 
+// Callers tune cacheSize/pageSize for the disk backend (snarkjs passes 8 MiB
+// pages); over HTTP a page that large turns a 4-byte header read into a
+// megabytes-range request -- for files below the page size, the whole file in
+// one response, defeating streaming. Cap pages at 64 KiB: big enough to
+// coalesce a binfile section-table scan, small enough to stay incidental.
+// Reads >= the page size bypass the cache entirely (RangeFile direct path),
+// so large section/chunk reads are unaffected by the cap.
+const MAX_HTTP_PAGE_SIZE = 1 << 16;
+
 async function readExisting$2(o) {
     const url = o.url;
     const probe = await fetch(url, { headers: { "Range": "bytes=0-0" } });
@@ -1194,7 +1203,8 @@ async function readExisting$2(o) {
             const readRangeInto = function (dst, dstOffset, pos, len) {
                 return httpReadRangeInto(url, validator, dst, dstOffset, pos, len);
             };
-            return new RangeFile(readRangeInto, totalSize, o.cacheSize, o.pageSize);
+            const pageSize = Math.min(o.pageSize || MAX_HTTP_PAGE_SIZE, MAX_HTTP_PAGE_SIZE);
+            return new RangeFile(readRangeInto, totalSize, o.cacheSize, pageSize);
         }
         // 206 but total size unknown (Content-Range: bytes 0-0/*): we cannot
         // do bounded positioned reads; refetch whole and buffer.
@@ -1294,6 +1304,12 @@ async function abandonBody(res) {
 
 // Read-only file over a Blob/File (e.g. a browser <input type="file">
 
+// Same rationale as httpfile's cap, relaxed for a local source: callers pass
+// disk-tuned page sizes (MiBs) that would make every small header read
+// materialize a huge slice; 1 MiB keeps that bounded while costing at most a
+// handful of slice reads per file open.
+const MAX_BLOB_PAGE_SIZE = 1 << 20;
+
 function readExisting$1(o) {
     const blob = o.blob;
     const readRangeInto = async function (dst, dstOffset, pos, len) {
@@ -1303,7 +1319,8 @@ function readExisting$1(o) {
         }
         dst.set(new Uint8Array(ab), dstOffset);
     };
-    return new RangeFile(readRangeInto, blob.size, o.cacheSize, o.pageSize);
+    const pageSize = Math.min(o.pageSize || MAX_BLOB_PAGE_SIZE, MAX_BLOB_PAGE_SIZE);
+    return new RangeFile(readRangeInto, blob.size, o.cacheSize, pageSize);
 }
 
 const DEFAULT_CACHE_SIZE = (1 << 16);

--- a/rollup.cjs.config.js
+++ b/rollup.cjs.config.js
@@ -10,7 +10,7 @@ export default {
         format: "cjs",
     },
     external: [
-        ...Object.keys(pkg.dependencies),
+        ...Object.keys(pkg.dependencies || {}),
         ...builtin,
     ]
 };

--- a/src/blobfile.js
+++ b/src/blobfile.js
@@ -1,0 +1,18 @@
+// Read-only file over a Blob/File (e.g. a browser <input type="file">
+// selection). blob.slice() is a zero-copy view; bytes only reach memory when
+// a sub-range is read, so large zkeys stream from disk chunk-by-chunk with
+// the same bounded footprint as the Node file backend.
+
+import { RangeFile } from "./rangefile.js";
+
+export function readExisting(o) {
+    const blob = o.blob;
+    const readRangeInto = async function (dst, dstOffset, pos, len) {
+        const ab = await blob.slice(pos, pos + len).arrayBuffer();
+        if (ab.byteLength !== len) {
+            throw new Error("short blob read (" + ab.byteLength + "/" + len + " bytes at " + pos + ")");
+        }
+        dst.set(new Uint8Array(ab), dstOffset);
+    };
+    return new RangeFile(readRangeInto, blob.size, o.cacheSize, o.pageSize);
+}

--- a/src/blobfile.js
+++ b/src/blobfile.js
@@ -5,6 +5,12 @@
 
 import { RangeFile } from "./rangefile.js";
 
+// Same rationale as httpfile's cap, relaxed for a local source: callers pass
+// disk-tuned page sizes (MiBs) that would make every small header read
+// materialize a huge slice; 1 MiB keeps that bounded while costing at most a
+// handful of slice reads per file open.
+const MAX_BLOB_PAGE_SIZE = 1 << 20;
+
 export function readExisting(o) {
     const blob = o.blob;
     const readRangeInto = async function (dst, dstOffset, pos, len) {
@@ -14,5 +20,6 @@ export function readExisting(o) {
         }
         dst.set(new Uint8Array(ab), dstOffset);
     };
-    return new RangeFile(readRangeInto, blob.size, o.cacheSize, o.pageSize);
+    const pageSize = Math.min(o.pageSize || MAX_BLOB_PAGE_SIZE, MAX_BLOB_PAGE_SIZE);
+    return new RangeFile(readRangeInto, blob.size, o.cacheSize, pageSize);
 }

--- a/src/fastfile.js
+++ b/src/fastfile.js
@@ -1,6 +1,8 @@
 import { open } from "./osfile.js";
 import * as memFile from "./memfile.js";
 import * as bigMemFile from "./bigmemfile.js";
+import * as httpFile from "./httpfile.js";
+import * as blobFile from "./blobfile.js";
 import { O_TRUNC, O_CREAT, O_RDWR, O_EXCL, O_RDONLY } from "constants";
 
 
@@ -59,20 +61,27 @@ export async function readExisting(o, b, c) {
             data: o
         };
     }
-    if (!isNode) {
-        if (typeof o === "string") {
-            const buff = await fetch(o).then( function(res) {
-                return res.arrayBuffer();
-            }).then(function (ab) {
-                return new Uint8Array(ab);
-            });
+    if (typeof Blob !== "undefined" && o instanceof Blob) {
+        o = {
+            type: "blob",
+            blob: o,
+            cacheSize: b,
+            pageSize: c
+        };
+    }
+    if (typeof o === "string") {
+        // URLs (and, in the browser, any string -- historically fetched
+        // whole) go through the http backend: it streams via Range requests
+        // when the server supports them and falls back to buffering the
+        // full body (the previous behavior) when it does not.
+        if (!isNode || /^https?:\/\//i.test(o)) {
             o = {
-                type: "mem",
-                data: buff
+                type: "http",
+                url: o,
+                cacheSize: b,
+                pageSize: c
             };
-        }
-    } else {
-        if (typeof o === "string") {
+        } else {
             o = {
                 type: "file",
                 fileName: o,
@@ -87,6 +96,10 @@ export async function readExisting(o, b, c) {
         return await memFile.readExisting(o);
     } else if (o.type == "bigMem") {
         return await bigMemFile.readExisting(o);
+    } else if (o.type == "http") {
+        return await httpFile.readExisting(o);
+    } else if (o.type == "blob") {
+        return blobFile.readExisting(o);
     } else {
         throw new Error("Invalid FastFile type: "+o.type);
     }

--- a/src/httpfile.js
+++ b/src/httpfile.js
@@ -1,0 +1,134 @@
+// Read-only file over HTTP(S) using Range requests.
+//
+// Open probes the server with `Range: bytes=0-0`:
+//   - 206 + parseable Content-Range total -> a RangeFile whose reads become
+//     range requests; large reads (zkey/ptau sections, MSM chunks) stream
+//     the response body straight into the caller's buffer, so the full file
+//     is never resident;
+//   - anything else (200, no range support, unknown total) -> fall back to
+//     buffering the body in memory, i.e. the historical browser behavior.
+//
+// Consistency: the validator captured at open (strong ETag, else
+// Last-Modified) is sent as If-Range on every range request. If the remote
+// file changes mid-read the server answers 200 instead of 206 and the read
+// throws, rather than silently mixing chunks of two file versions.
+//
+// Server requirements (CORS deployments): allow the `Range` request header
+// and expose `Content-Range` + `ETag`; serve zkeys without Content-Encoding
+// (ranges address encoded bytes).
+
+import { RangeFile } from "./rangefile.js";
+import * as memFile from "./memfile.js";
+
+export async function readExisting(o) {
+    const url = o.url;
+    const probe = await fetch(url, { headers: { "Range": "bytes=0-0" } });
+
+    if (probe.status === 206) {
+        const contentRange = probe.headers.get("content-range");
+        const m = contentRange ? /\/(\d+)\s*$/.exec(contentRange) : null;
+        if (m) {
+            const totalSize = parseInt(m[1]);
+            // Drain the 1-byte probe body so the connection can be reused.
+            await probe.arrayBuffer();
+            const validator = strongValidator(probe);
+            const readRangeInto = function (dst, dstOffset, pos, len) {
+                return httpReadRangeInto(url, validator, dst, dstOffset, pos, len);
+            };
+            return new RangeFile(readRangeInto, totalSize, o.cacheSize, o.pageSize);
+        }
+        // 206 but total size unknown (Content-Range: bytes 0-0/*): we cannot
+        // do bounded positioned reads; refetch whole and buffer.
+        await probe.arrayBuffer();
+        return await readFullyToMem(url);
+    }
+
+    if (!probe.ok && probe.status !== 416) {
+        throw new Error("HTTP " + probe.status + " fetching " + url);
+    }
+
+    if (probe.status === 416) {
+        // Range not satisfiable -- only legitimate for an empty file.
+        const contentRange = probe.headers.get("content-range");
+        if (contentRange && /\/0\s*$/.test(contentRange)) {
+            return memFile.readExisting({ type: "mem", data: new Uint8Array(0) });
+        }
+        return await readFullyToMem(url);
+    }
+
+    // 200: the server ignored Range and sent the whole file; reuse this body.
+    const data = new Uint8Array(await probe.arrayBuffer());
+    return memFile.readExisting({ type: "mem", data: data });
+}
+
+async function readFullyToMem(url) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error("HTTP " + res.status + " fetching " + url);
+    const data = new Uint8Array(await res.arrayBuffer());
+    return memFile.readExisting({ type: "mem", data: data });
+}
+
+// Only a strong validator is usable with If-Range (RFC 9110 §13.1.5): a weak
+// ETag would make conditional range requests always fail on some servers.
+function strongValidator(res) {
+    const etag = res.headers.get("etag");
+    if (etag && etag.indexOf("W/") !== 0) return etag;
+    const lastModified = res.headers.get("last-modified");
+    if (lastModified) return lastModified;
+    return null;
+}
+
+async function httpReadRangeInto(url, validator, dst, dstOffset, pos, len) {
+    const headers = { "Range": "bytes=" + pos + "-" + (pos + len - 1) };
+    if (validator) headers["If-Range"] = validator;
+    const res = await fetch(url, { headers: headers });
+    if (res.status === 200) {
+        // With If-Range this is the server signalling the file changed;
+        // without it, the server stopped honoring ranges mid-session.
+        await abandonBody(res);
+        throw new Error(url + ": file changed (or server stopped honoring Range) while reading");
+    }
+    if (res.status !== 206) {
+        await abandonBody(res);
+        throw new Error("HTTP " + res.status + " reading range " + pos + "+" + len + " of " + url);
+    }
+    const contentRange = res.headers.get("content-range");
+    const m = contentRange ? /bytes\s+(\d+)-(\d+)\//.exec(contentRange) : null;
+    if (m && parseInt(m[1]) !== pos) {
+        await abandonBody(res);
+        throw new Error(url + ": server returned range starting at " + m[1] + ", requested " + pos);
+    }
+
+    // Stream the body straight into the destination (typed array or
+    // BigBuffer -- both expose .set(chunk, offset)); avoids materializing
+    // a second full-size copy of large section reads.
+    let done = 0;
+    if (res.body && typeof res.body.getReader === "function") {
+        const reader = res.body.getReader();
+        for (;;) {
+            const it = await reader.read();
+            if (it.done) break;
+            if (done + it.value.byteLength > len) {
+                reader.cancel().catch(function () {});
+                throw new Error(url + ": range response longer than requested");
+            }
+            dst.set(it.value, dstOffset + done);
+            done += it.value.byteLength;
+        }
+    } else {
+        const buff = new Uint8Array(await res.arrayBuffer());
+        if (buff.byteLength > len) throw new Error(url + ": range response longer than requested");
+        dst.set(buff, dstOffset);
+        done = buff.byteLength;
+    }
+    if (done !== len) {
+        throw new Error(url + ": short range response (" + done + "/" + len + " bytes at " + pos + ")");
+    }
+}
+
+async function abandonBody(res) {
+    try {
+        if (res.body && typeof res.body.cancel === "function") await res.body.cancel();
+        else await res.arrayBuffer();
+    } catch (e) { /* body teardown is best-effort */ }
+}

--- a/src/httpfile.js
+++ b/src/httpfile.js
@@ -20,6 +20,15 @@
 import { RangeFile } from "./rangefile.js";
 import * as memFile from "./memfile.js";
 
+// Callers tune cacheSize/pageSize for the disk backend (snarkjs passes 8 MiB
+// pages); over HTTP a page that large turns a 4-byte header read into a
+// megabytes-range request -- for files below the page size, the whole file in
+// one response, defeating streaming. Cap pages at 64 KiB: big enough to
+// coalesce a binfile section-table scan, small enough to stay incidental.
+// Reads >= the page size bypass the cache entirely (RangeFile direct path),
+// so large section/chunk reads are unaffected by the cap.
+const MAX_HTTP_PAGE_SIZE = 1 << 16;
+
 export async function readExisting(o) {
     const url = o.url;
     const probe = await fetch(url, { headers: { "Range": "bytes=0-0" } });
@@ -35,7 +44,8 @@ export async function readExisting(o) {
             const readRangeInto = function (dst, dstOffset, pos, len) {
                 return httpReadRangeInto(url, validator, dst, dstOffset, pos, len);
             };
-            return new RangeFile(readRangeInto, totalSize, o.cacheSize, o.pageSize);
+            const pageSize = Math.min(o.pageSize || MAX_HTTP_PAGE_SIZE, MAX_HTTP_PAGE_SIZE);
+            return new RangeFile(readRangeInto, totalSize, o.cacheSize, pageSize);
         }
         // 206 but total size unknown (Content-Range: bytes 0-0/*): we cannot
         // do bounded positioned reads; refetch whole and buffer.

--- a/src/rangefile.js
+++ b/src/rangefile.js
@@ -1,0 +1,181 @@
+// Shared read-only file over an abstract positioned range reader.
+//
+// Backends (httpfile, blobfile) supply a single primitive:
+//     readRangeInto(dstBuff, dstOffset, pos, len) -> Promise<void>
+// and this class layers the FastFile read interface on top:
+//   - reads >= pageSize bypass the cache and go straight to the backend
+//     (the file is read-only, so a direct read is always coherent);
+//   - smaller reads (header scans: magics, section tables, ULE32/64) are
+//     served from page-aligned cached ranges so that e.g. a binfile section
+//     scan does not issue one backend request per 4-byte field.
+//
+// Write operations throw: remote ranges are strictly a read transport.
+
+const DEFAULT_CACHE_SIZE = 1 << 20;
+const DEFAULT_PAGE_SIZE = 1 << 13;
+
+export class RangeFile {
+
+    constructor(readRangeInto, totalSize, cacheSize, pageSize) {
+        this.readRangeInto = readRangeInto;
+        this.totalSize = totalSize;
+        this.pos = 0;
+        this.pageSize = pageSize || DEFAULT_PAGE_SIZE;
+        this.maxPagesLoaded = Math.floor((cacheSize || DEFAULT_CACHE_SIZE) / this.pageSize) + 1;
+        this.pages = new Map();      // page index -> { buff: Uint8Array|null, promise: Promise }
+        this.readOnly = true;
+    }
+
+    _pageLen(p) {
+        const start = p * this.pageSize;
+        const end = Math.min(start + this.pageSize, this.totalSize);
+        return end - start;
+    }
+
+    // Load (or join the in-flight load of) page p; resolves to its buffer.
+    // A failed load removes the entry so a later retry re-requests it.
+    _loadPage(p) {
+        const self = this;
+        let page = self.pages.get(p);
+        if (page) {
+            // LRU touch: re-insert so Map iteration order tracks recency.
+            self.pages.delete(p);
+            self.pages.set(p, page);
+            return page.promise;
+        }
+        const buff = new Uint8Array(self._pageLen(p));
+        page = { buff: null, promise: null };
+        page.promise = self.readRangeInto(buff, 0, p * self.pageSize, buff.byteLength).then(function () {
+            page.buff = buff;
+            return buff;
+        }, function (err) {
+            self.pages.delete(p);
+            throw err;
+        });
+        self.pages.set(p, page);
+        self._trimCache();
+        return page.promise;
+    }
+
+    _trimCache() {
+        const self = this;
+        if (self.pages.size <= self.maxPagesLoaded) return;
+        // Evict oldest settled pages first; in-flight loads are kept.
+        for (const entry of self.pages) {
+            if (self.pages.size <= self.maxPagesLoaded) return;
+            if (entry[1].buff) self.pages.delete(entry[0]);
+        }
+    }
+
+    async readToBuffer(buffDst, offset, len, pos) {
+        const self = this;
+        if (len === 0) return;
+        if (self.pendingClose) throw new Error("Reading a closing file");
+        if (typeof pos === "undefined") pos = self.pos;
+        if (pos + len > self.totalSize) throw new Error("Reading out of bounds");
+        self.pos = pos + len;
+
+        // Direct path: one backend request straight into the destination
+        // (works for both typed arrays and BigBuffer via .set()).
+        if (len >= self.pageSize) {
+            await self.readRangeInto(buffDst, offset, pos, len);
+            return;
+        }
+
+        const firstPage = Math.floor(pos / self.pageSize);
+        const lastPage = Math.floor((pos + len - 1) / self.pageSize);
+        let o = pos % self.pageSize;
+        let done = 0;
+        for (let p = firstPage; p <= lastPage; p++) {
+            const buff = await self._loadPage(p);
+            const l = Math.min(len - done, self.pageSize - o);
+            buffDst.set(buff.subarray(o, o + l), offset + done);
+            done += l;
+            o = 0;
+        }
+    }
+
+    async read(len, pos) {
+        const buff = new Uint8Array(len);
+        await this.readToBuffer(buff, 0, len, pos);
+        return buff;
+    }
+
+    async readULE32(pos) {
+        const b = await this.read(4, pos);
+        const view = new Uint32Array(b.buffer);
+        return view[0];
+    }
+
+    async readUBE32(pos) {
+        const b = await this.read(4, pos);
+        const view = new DataView(b.buffer);
+        return view.getUint32(0, false);
+    }
+
+    async readULE64(pos) {
+        const b = await this.read(8, pos);
+        const view = new Uint32Array(b.buffer);
+        return view[1] * 0x100000000 + view[0];
+    }
+
+    async readString(pos) {
+        const self = this;
+        if (self.pendingClose) throw new Error("Reading a closing file");
+        let p = typeof pos === "undefined" ? self.pos : pos;
+        const chunks = [];
+        while (p < self.totalSize) {
+            const l = Math.min(self.pageSize, self.totalSize - p);
+            const chunk = await self.read(l, p);
+            const z = chunk.indexOf(0);
+            if (z >= 0) {
+                chunks.push(chunk.subarray(0, z));
+                self.pos = p + z + 1;
+                return decodeChunks(chunks);
+            }
+            chunks.push(chunk);
+            p += l;
+        }
+        // No terminator before EOF: the string ends at EOF.
+        self.pos = p;
+        return decodeChunks(chunks);
+    }
+
+    async write() {
+        throw new Error("Writing a read only file");
+    }
+
+    async writeULE32() {
+        throw new Error("Writing a read only file");
+    }
+
+    async writeUBE32() {
+        throw new Error("Writing a read only file");
+    }
+
+    async writeULE64() {
+        throw new Error("Writing a read only file");
+    }
+
+    async close() {
+        if (this.pendingClose) throw new Error("Closing the file twice");
+        this.pendingClose = true;
+        this.pages.clear();
+    }
+
+    async discard() {
+        await this.close();
+    }
+}
+
+function decodeChunks(chunks) {
+    let total = 0;
+    for (let i = 0; i < chunks.length; i++) total += chunks[i].byteLength;
+    const all = new Uint8Array(total);
+    let o = 0;
+    for (let i = 0; i < chunks.length; i++) {
+        all.set(chunks[i], o);
+        o += chunks[i].byteLength;
+    }
+    return new TextDecoder().decode(all);
+}

--- a/test/blobfile.test.js
+++ b/test/blobfile.test.js
@@ -1,0 +1,50 @@
+import * as fastFile from "../src/fastfile.js";
+
+import assert from "assert";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+function makeData(n) {
+    const data = new Uint8Array(n);
+    let x = 0x9E3779B9;
+    for (let i = 0; i < n; i++) {
+        x ^= x << 13; x >>>= 0;
+        x ^= x >> 17;
+        x ^= x << 5; x >>>= 0;
+        data[i] = x & 0xFF;
+    }
+    return data;
+}
+
+describe("fastfile testing suite for blobfile", function () {
+    this.timeout(100000);
+
+    it("should read positioned ranges from a Blob", async () => {
+        const data = makeData(1 << 18);
+        const fd = await fastFile.readExisting(new Blob([data]));
+        assert.strictEqual(fd.totalSize, data.length);
+
+        const head = await fd.read(4, 0);
+        assert.deepStrictEqual(Buffer.from(head), Buffer.from(data.slice(0, 4)));
+
+        const big = new Uint8Array(100000);
+        await fd.readToBuffer(big, 0, big.length, 30000);
+        assert.deepStrictEqual(Buffer.from(big), Buffer.from(data.slice(30000, 130000)));
+
+        const v = await fd.readULE64(1024);
+        const dv = new DataView(data.buffer);
+        assert.strictEqual(v, dv.getUint32(1028, true) * 0x100000000 + dv.getUint32(1024, true));
+
+        await fd.close();
+    });
+
+    it("should reject reads out of bounds and any write", async () => {
+        const fd = await fastFile.readExisting(new Blob([makeData(100)]));
+        await expect(fd.read(8, 96)).to.be.rejectedWith(/out of bounds/);
+        await expect(fd.write(new Uint8Array(4), 0)).to.be.rejectedWith(/read only/);
+        await fd.close();
+    });
+});

--- a/test/httpfile.test.js
+++ b/test/httpfile.test.js
@@ -1,0 +1,215 @@
+import * as fastFile from "../src/fastfile.js";
+
+import http from "http";
+import assert from "assert";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+// Deterministic pseudo-random content so failures are reproducible.
+function makeData(n) {
+    const data = new Uint8Array(n);
+    let x = 0x12345678;
+    for (let i = 0; i < n; i++) {
+        x ^= x << 13; x >>>= 0;
+        x ^= x >> 17;
+        x ^= x << 5; x >>>= 0;
+        data[i] = x & 0xFF;
+    }
+    return data;
+}
+
+// Minimal static server. opts:
+//   ranges: false  -> ignore Range headers, always 200 full body
+//   etag           -> served as ETag; If-Range mismatches answer 200 full
+// state.data / state.etag may be swapped mid-test to simulate a changed file.
+function startServer(state, opts) {
+    opts = opts || {};
+    const log = { requests: [], bytesServed: 0 };
+    const server = http.createServer(function (req, res) {
+        const entry = { range: req.headers.range || null, ifRange: req.headers["if-range"] || null };
+        log.requests.push(entry);
+        const data = state.data;
+        const headers = {};
+        if (state.etag) headers["ETag"] = state.etag;
+
+        const m = (opts.ranges !== false && req.headers.range) ?
+            /^bytes=(\d+)-(\d+)$/.exec(req.headers.range) : null;
+        const ifRangeOk = !req.headers["if-range"] || req.headers["if-range"] === state.etag;
+
+        if (m && ifRangeOk) {
+            const start = parseInt(m[1]);
+            if (start >= data.length) {
+                headers["Content-Range"] = "bytes */" + data.length;
+                res.writeHead(416, headers);
+                res.end();
+                return;
+            }
+            const end = Math.min(parseInt(m[2]), data.length - 1);
+            const body = Buffer.from(data.slice(start, end + 1));
+            headers["Content-Range"] = "bytes " + start + "-" + end + "/" + data.length;
+            headers["Content-Length"] = body.length;
+            headers["Accept-Ranges"] = "bytes";
+            res.writeHead(206, headers);
+            log.bytesServed += body.length;
+            res.end(body);
+        } else {
+            const body = Buffer.from(data);
+            headers["Content-Length"] = body.length;
+            res.writeHead(200, headers);
+            log.bytesServed += body.length;
+            res.end(body);
+        }
+    });
+    return new Promise(function (resolve) {
+        server.listen(0, "127.0.0.1", function () {
+            resolve({
+                server: server,
+                log: log,
+                url: "http://127.0.0.1:" + server.address().port + "/data.bin",
+                close: function () {
+                    return new Promise(function (res2) { server.close(res2); });
+                }
+            });
+        });
+    });
+}
+
+describe("fastfile testing suite for httpfile", function () {
+    this.timeout(100000);
+
+    it("should read ranges without ever downloading the full file", async () => {
+        const data = makeData(1 << 20);   // 1 MiB
+        const srv = await startServer({ data: data, etag: "\"v1\"" });
+        try {
+            const fd = await fastFile.readExisting(srv.url);
+            assert.strictEqual(fd.totalSize, data.length);
+
+            // header-style small reads
+            const head = await fd.read(4, 0);
+            assert.deepStrictEqual([...head], [...data.slice(0, 4)]);
+            const v = await fd.readULE32(4);
+            assert.strictEqual(v, new DataView(data.buffer).getUint32(4, true));
+
+            // large positioned read (direct path)
+            const big = new Uint8Array(300000);
+            await fd.readToBuffer(big, 0, big.length, 500000);
+            assert.deepStrictEqual(Buffer.from(big), Buffer.from(data.slice(500000, 800000)));
+
+            // scattered small reads (cached path), spanning a page boundary
+            const ps = fd.pageSize;
+            const cross = await fd.read(16, ps - 8);
+            assert.deepStrictEqual(Buffer.from(cross), Buffer.from(data.slice(ps - 8, ps + 8)));
+
+            await fd.close();
+
+            // every request carried a Range header (no full-file GET) ...
+            for (const r of srv.log.requests) assert.ok(r.range, "expected only range requests");
+            // ... and far less than the file was transferred
+            assert.ok(srv.log.bytesServed < data.length / 2,
+                "served " + srv.log.bytesServed + " of " + data.length);
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it("should serve repeated small reads on one page from cache (single request)", async () => {
+        const data = makeData(1 << 16);
+        const srv = await startServer({ data: data, etag: "\"v1\"" });
+        try {
+            const fd = await fastFile.readExisting(srv.url);
+            const before = srv.log.requests.length;
+            await fd.read(4, 100);
+            await fd.read(4, 200);
+            await fd.readULE64(300);
+            assert.strictEqual(srv.log.requests.length, before + 1);
+            await fd.close();
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it("should read sequentially without explicit positions", async () => {
+        const data = makeData(4096);
+        const srv = await startServer({ data: data });
+        try {
+            const fd = await fastFile.readExisting(srv.url);
+            const a = await fd.read(10);
+            const b = await fd.read(10);
+            assert.deepStrictEqual(Buffer.concat([Buffer.from(a), Buffer.from(b)]), Buffer.from(data.slice(0, 20)));
+            assert.strictEqual(fd.pos, 20);
+            await fd.close();
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it("should fall back to full buffering when the server ignores Range", async () => {
+        const data = makeData(100000);
+        const srv = await startServer({ data: data }, { ranges: false });
+        try {
+            const fd = await fastFile.readExisting(srv.url);
+            assert.strictEqual(fd.totalSize, data.length);
+            const all = await fd.read(data.length, 0);
+            assert.deepStrictEqual(Buffer.from(all), Buffer.from(data));
+            await fd.close();
+            // the probe response body was reused: exactly one request
+            assert.strictEqual(srv.log.requests.length, 1);
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it("should fail a read when the remote file changes mid-session (If-Range)", async () => {
+        const state = { data: makeData(1 << 20), etag: "\"v1\"" };
+        const srv = await startServer(state);
+        try {
+            const fd = await fastFile.readExisting(srv.url);
+            const buff = new Uint8Array(1 << 16);
+            await fd.readToBuffer(buff, 0, buff.length, 0);   // works on v1
+
+            state.data = makeData(1 << 20).map(function (b) { return b ^ 0xFF; });
+            state.etag = "\"v2\"";
+
+            // direct (uncached) read must reject, not silently mix versions
+            await expect(fd.readToBuffer(new Uint8Array(1 << 16), 0, 1 << 16, 1 << 17))
+                .to.be.rejectedWith(/file changed/);
+            await fd.close();
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it("should reject reads out of bounds and any write", async () => {
+        const data = makeData(1000);
+        const srv = await startServer({ data: data, etag: "\"v1\"" });
+        try {
+            const fd = await fastFile.readExisting(srv.url);
+            await expect(fd.read(16, 992)).to.be.rejectedWith(/out of bounds/);
+            await expect(fd.write(new Uint8Array(4), 0)).to.be.rejectedWith(/read only/);
+            await expect(fd.writeULE32(1, 0)).to.be.rejectedWith(/read only/);
+            await fd.close();
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it("should read strings through the page cache", async () => {
+        const data = makeData(9000);
+        const msg = "hello_snarkjs";
+        for (let i = 0; i < msg.length; i++) data[8000 + i] = msg.charCodeAt(i);
+        data[8000 + msg.length] = 0;
+        const srv = await startServer({ data: data, etag: "\"v1\"" });
+        try {
+            const fd = await fastFile.readExisting(srv.url);
+            const str = await fd.readString(8000);
+            assert.strictEqual(str, msg);
+            assert.strictEqual(fd.pos, 8000 + msg.length + 1);
+            await fd.close();
+        } finally {
+            await srv.close();
+        }
+    });
+});

--- a/test/httpfile.test.js
+++ b/test/httpfile.test.js
@@ -27,7 +27,7 @@ function makeData(n) {
 // state.data / state.etag may be swapped mid-test to simulate a changed file.
 function startServer(state, opts) {
     opts = opts || {};
-    const log = { requests: [], bytesServed: 0 };
+    const log = { requests: [], bytesServed: 0, maxResponse: 0 };
     const server = http.createServer(function (req, res) {
         const entry = { range: req.headers.range || null, ifRange: req.headers["if-range"] || null };
         log.requests.push(entry);
@@ -54,6 +54,7 @@ function startServer(state, opts) {
             headers["Accept-Ranges"] = "bytes";
             res.writeHead(206, headers);
             log.bytesServed += body.length;
+            log.maxResponse = Math.max(log.maxResponse, body.length);
             res.end(body);
         } else {
             const body = Buffer.from(data);
@@ -190,6 +191,22 @@ describe("fastfile testing suite for httpfile", function () {
             await expect(fd.read(16, 992)).to.be.rejectedWith(/out of bounds/);
             await expect(fd.write(new Uint8Array(4), 0)).to.be.rejectedWith(/read only/);
             await expect(fd.writeULE32(1, 0)).to.be.rejectedWith(/read only/);
+            await fd.close();
+        } finally {
+            await srv.close();
+        }
+    });
+
+    it("should cap disk-tuned page-size hints (small read must not fetch the file)", async () => {
+        const data = makeData(1 << 19);   // 512 KiB, well under an 8 MiB "page"
+        const srv = await startServer({ data: data, etag: "\"v1\"" });
+        try {
+            // snarkjs-style hints: 32 MiB cache, 8 MiB pages (meant for disk)
+            const fd = await fastFile.readExisting(srv.url, 1 << 25, 1 << 23);
+            await fd.read(4, 0);
+            await fd.readULE64(300000);
+            assert.ok(srv.log.maxResponse <= 1 << 16,
+                "largest response was " + srv.log.maxResponse + " bytes; page hint not capped");
             await fd.close();
         } finally {
             await srv.close();


### PR DESCRIPTION
# Stream reads over HTTP Range requests and from Blobs

**Stacked on #138 (`feature/direct_rw_optimization`)** — this PR
shows only the two streaming commits.

## Summary

`readExisting` with a URL previously buffered the entire response in memory
(the browser path fetched any string whole; Node had no URL support at all).
That defeated chunked zkey streaming for browser provers: the full zkey was
resident before the first section read.

Now a URL opens a range-backed read-only fd:

- **Open probe**: one `GET` with `Range: bytes=0-0`. A `206` gives range
  support, the total size (from `Content-Range`), and a validator (strong
  `ETag`, else `Last-Modified`) in a single round trip. Anything else falls
  back to the historical buffer-it-all behavior, reusing the probe's own
  response body (no second fetch).
- **Large reads** (≥ page size) become one Range request each, streaming the
  response body directly into the caller's buffer (typed array or BigBuffer)
  — no second full-size copy. With snarkjs' chunked section readers, the
  zkey's point sections are never resident as a whole.
- **Small header reads** (binfile magic, section table scans) coalesce into
  page-aligned cached ranges (LRU) instead of issuing one HTTP request per
  4-byte field. Pages are capped at 64 KiB regardless of the caller's
  disk-tuned pageSize hints — snarkjs passes 8 MiB pages, which would
  otherwise turn a 4-byte header read into a whole-file range request.
- **Consistency**: every range request carries `If-Range` with the validator
  captured at open. If the remote file changes mid-read, the server answers
  `200` and the read throws instead of silently mixing chunks of two file
  versions.
- **Blob/File backend**: `readExisting(blob)` streams via
  `blob.slice(pos, pos+len).arrayBuffer()` — a browser `<input type="file">`
  zkey reads from disk chunk-by-chunk with the same bounded footprint as the
  Node file backend (pages capped at 1 MiB).

Both backends share one implementation (`src/rangefile.js`), parameterized by
a positioned `readRangeInto(dst, dstOffset, pos, len)` primitive. Write
operations throw; the transport is strictly read-only.

## Server requirements (CORS deployments)

- Allow the `Range` request header; expose `Content-Range`, `ETag`,
  `Accept-Ranges`.
- Serve without `Content-Encoding` (ranges address encoded bytes; zkey
  content is high-entropy anyway). S3/GCS/CloudFront work out of the box.

## Validation

`npm test`: 31 passing, including 10 new tests against local HTTP servers:
range streaming with request accounting (no full-file GET ever issued),
single-request page-cache reuse, sequential unpositioned reads, the
no-range-support fallback (exactly one request), mid-session file-change
rejection via If-Range, out-of-bounds/write rejection, string reads through
the page cache, the disk-hint page-size cap, and Blob positioned reads.

Downstream, binfileutils gained URL round-trip tests (header scan + full and
partial section reads in both server modes) and snarkjs an e2e test proving
groth16 with the zkey served by a local range server — proof verifies, every
request is a Range request, and no single response carries the whole zkey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wo6AVSAwvL9mHTpvnREZPR
